### PR TITLE
Drop depends on old protobuf package

### DIFF
--- a/runner/genreflectionserver/cmd_test.go
+++ b/runner/genreflectionserver/cmd_test.go
@@ -1,14 +1,14 @@
 package genreflectionserver_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/bradleyjkemp/cupaloy/v2"
-	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 	"github.com/rerost/giro/runner/genreflectionserver"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/descriptorpb"
 	"google.golang.org/protobuf/types/pluginpb"
 )
@@ -18,7 +18,7 @@ const (
 )
 
 func request(testset string) (*pluginpb.CodeGeneratorRequest, error) {
-	f, err := ioutil.ReadFile(filepath.Join(testData, testset))
+	f, err := os.ReadFile(filepath.Join(testData, testset))
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -40,7 +40,7 @@ func request(testset string) (*pluginpb.CodeGeneratorRequest, error) {
 }
 
 func TestRun(t *testing.T) {
-	protos, err := ioutil.ReadDir(testData)
+	protos, err := os.ReadDir(testData)
 	if err != nil {
 		t.Error(err)
 		return


### PR DESCRIPTION
"github.com/jhump/protoreflect" -> "github.com/golang/protobuf/jsonpb"  の依存が消せないので、`github.com/golang/protobuf` には依存し続けてしまうが、依存を減らしたい

https://github.com/rerost/giro/blob/a71c3d8e4742ea67cba09526a8e1b8267840a805/domain/message/message.go#L50