### PR TITLE
Upgrade bundler

### DIFF
--- a/example/multiple_package/server/Gemfile.lock
+++ b/example/multiple_package/server/Gemfile.lock
@@ -20,4 +20,4 @@ DEPENDENCIES
   grpc (~> 1.34)
 
 BUNDLED WITH
-   2.1.4
+   2.6.2


### PR DESCRIPTION
Fix error in https://github.com/rerost/giro/pull/108

```
#9 [3/5] COPY Gemfile.lock ./
#9 DONE 0.0s

#10 [4/5] RUN bundle install
#10 0.168 Bundler 2.6.2 is running, but your lockfile was generated with 2.1.4. Installing Bundler 2.1.4 and restarting using that version.
#10 0.945 Fetching gem metadata from [https://rubygems.org/.](https://rubygems.org/)
#10 0.973 Fetching bundler 2.1.4
#10 1.076 Installing bundler 2.1.4
#10 1.292 /usr/local/bundle/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/error.rb:105:in '<class:Thor>': uninitialized constant DidYouMean::SPELL_CHECKERS (NameError)
#10 1.292 
#10 1.292     DidYouMean::SPELL_CHECKERS.merge!(
#10 1.292               ^^^^^^^^^^^^^^^^
#10 1.292 Did you mean?  DidYouMean::SpellChecker
#10 1.292 	from /usr/local/bundle/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/error.rb:1:in '<top (required)>'
#10 1.292 	from /usr/local/bundle/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/base.rb:3:in 'Kernel#require_relative'
#10 1.292 	from /usr/local/bundle/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/base.rb:3:in '<top (required)>'
#10 1.292 	from /usr/local/bundle/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor.rb:2:in 'Kernel#require_relative'
#10 1.292 	from /usr/local/bundle/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor.rb:2:in '<top (required)>'
#10 1.292 	from /usr/local/bundle/gems/bundler-2.1.4/lib/bundler/vendored_thor.rb:8:in 'Kernel#require_relative'
#10 1.292 	from /usr/local/bundle/gems/bundler-2.1.4/lib/bundler/vendored_thor.rb:8:in '<top (required)>'
#10 1.292 	from /usr/local/bundle/gems/bundler-2.1.4/lib/bundler/friendly_errors.rb:3:in 'Kernel#require_relative'
#10 1.292 	from /usr/local/bundle/gems/bundler-2.1.4/lib/bundler/friendly_errors.rb:3:in '<top (required)>'
#10 1.292 	from /usr/local/bundle/gems/bundler-2.1.4/exe/bundle:29:in 'Kernel#require_relative'
#10 1.292 	from /usr/local/bundle/gems/bundler-2.1.4/exe/bundle:29:in '<top (required)>'
#10 1.292 	from /usr/local/bin/bundle:25:in 'Kernel#load'
#10 1.292 	from /usr/local/bin/bundle:25:in '<main>'
#10 ERROR: process "/bin/sh -c bundle install" did not complete successfully: exit code: 1
------
 > [4/5] RUN bundle install:
1.292 	from /usr/local/bundle/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor.rb:2:in 'Kernel#require_relative'
1.292 	from /usr/local/bundle/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor.rb:2:in '<top (required)>'
1.292 	from /usr/local/bundle/gems/bundler-2.1.4/lib/bundler/vendored_thor.rb:8:in 'Kernel#require_relative'
1.292 	from /usr/local/bundle/gems/bundler-2.1.4/lib/bundler/vendored_thor.rb:8:in '<top (required)>'
1.292 	from /usr/local/bundle/gems/bundler-2.1.4/lib/bundler/friendly_errors.rb:3:in 'Kernel#require_relative'
1.292 	from /usr/local/bundle/gems/bundler-2.1.4/lib/bundler/friendly_errors.rb:3:in '<top (required)>'
1.292 	from /usr/local/bundle/gems/bundler-2.1.4/exe/bundle:29:in 'Kernel#require_relative'
1.292 	from /usr/local/bundle/gems/bundler-2.1.4/exe/bundle:29:in '<top (required)>'
1.292 	from /usr/local/bin/bundle:25:in 'Kernel#load'
1.292 	from /usr/local/bin/bundle:25:in '<main>'
------
Dockerfile:6
--------------------
   4 |     COPY Gemfile.lock ./
   5 |     
   6 | >>> RUN bundle install
   7 |     
   8 |     COPY . .
--------------------
ERROR: failed to solve: process "/bin/sh -c bundle install" did not complete successfully: exit code: 1
```