### PR TITLE
Add dummy server command

### DIFF
--- a/cmd/dummyserver/main.go
+++ b/cmd/dummyserver/main.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/rerost/giro/e2etest/dummyserver"
+)
+
+func main() {
+	closer, err := dummyserver.Run("5000")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to run server: %v", err)
+		os.Exit(1)
+	}
+	defer closer()
+
+	// ここでサーバを起動しっぱなしにする
+	select {}
+}


### PR DESCRIPTION
https://github.com/rerost/giro/pull/132 のようなとき、テストではなく実際の挙動を試したい

```
(arm64) $  go run cmd/dummyserver/main.go
2025/02/16 11:36:29 listen: 5000
^Csignal: interrupt

```

開発ように5000番で立ち上がるダミーサーバをぱっと立てたい
※ https://github.com/rerost/giro/blob/f1443ce0a3a13e5413a125f99aea03c5d82a5912/.goreleaser.yml#L8-L33 で宣言しないため、brewなどでは配布されない