### PR TITLE
  • DEPRECATED: brews should not be used anymore, check https://goreleaser.com/deprecations#brews for more info

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,9 +49,10 @@ changelog:
     exclude:
       - '^docs:'
       - '^test:'
-brews:
-  - repository:
+homebrew_casks:
+  - name: giro
+    repository:
       owner: rerost
       name: homebrew-tools
-    directory: Formula
+    directory: Casks
     homepage: https://github.com/rerost/giro


### PR DESCRIPTION
FIx
>   • DEPRECATED: brews should not be used anymore, check https://goreleaser.com/deprecations#brews for more info

```
Warning: You are using 'latest' as default version. Will lock to '~> v2'.
Downloading https://github.com/goreleaser/goreleaser/releases/download/v2.10.2/goreleaser_Linux_x86_64.tar.gz
Extracting GoReleaser
/usr/bin/tar xz --warning=no-unknown-keyword --overwrite -C /home/runner/work/_temp/b043fc36-e41d-4a43-9f8c-1bc7ed33dbf3 -f /home/runner/work/_temp/c2b2861e-2d58-4d31-8[11](https://github.com/rerost/giro/actions/runs/15793809654/job/44523216697#step:3:12)0-587ba0ff97b7
GoReleaser latest installed successfully
/opt/hostedtoolcache/goreleaser-action/2.10.2/x64/goreleaser check
  • checking                                 path=.goreleaser.yml
  • DEPRECATED: brews should not be used anymore, check https://goreleaser.com/deprecations#brews for more info
  • .goreleaser.yml                                  error=configuration is valid, but uses deprecated properties
  ⨯ command failed                                   error=1 out of 1 configuration file(s) have issues
```