### PR TITLE
Fix e2e test for grpc-go v1.80.0 upgrade

### DIFF
--- a/e2etest/testdata/test.ct
+++ b/e2etest/testdata/test.ct
@@ -24,10 +24,10 @@ $ giro host rerost.giro.v1.TestService
 localhost:5000
 
 $ giro call rerost.giro.v1.TestService/Echo {"message":"Test"} --metadata=key1:val1:key2:val2
-{"message":"Test", "metadata":{"metadata":{":authority":{"value":["localhost:5000"]}, "content-type":{"value":["application/grpc"]}, "key1":{"value":["val1"]}, "key2":{"value":["val2"]}, "user-agent":{"value":["grpc-go/1.79.3"]}}}}
+{"message":"Test", "metadata":{"metadata":{":authority":{"value":["localhost:5000"]}, "content-type":{"value":["application/grpc"]}, "key1":{"value":["val1"]}, "key2":{"value":["val2"]}, "user-agent":{"value":["grpc-go/1.80.0"]}}}}
 
 $ giro call rerost.giro.v1.TestService/EmptyCall {} --metadata=key1:val1:key2:val2
-{"status":"ok", "metadata":{"metadata":{":authority":{"value":["localhost:5000"]}, "content-type":{"value":["application/grpc"]}, "key1":{"value":["val1"]}, "key2":{"value":["val2"]}, "user-agent":{"value":["grpc-go/1.79.3"]}}}}
+{"status":"ok", "metadata":{"metadata":{":authority":{"value":["localhost:5000"]}, "content-type":{"value":["application/grpc"]}, "key1":{"value":["val1"]}, "key2":{"value":["val2"]}, "user-agent":{"value":["grpc-go/1.80.0"]}}}}
 
 $ giro empty_json rerost.giro.v1.EchoRequest
 {"message":""}


### PR DESCRIPTION
## Summary
- Update e2e test golden file (`e2etest/testdata/test.ct`) to expect `grpc-go/1.80.0` in the user-agent string, matching the grpc dependency update in #277

## Test plan
- [ ] CI passes on the renovate branch after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)