### PR TITLE
Update module google.golang.org/grpc to v1.81.0 (with e2e test fix)

### DIFF
--- a/e2etest/testdata/test.ct
+++ b/e2etest/testdata/test.ct
@@ -24,10 +24,10 @@ $ giro host rerost.giro.v1.TestService
 localhost:5000
 
 $ giro call rerost.giro.v1.TestService/Echo {"message":"Test"} --metadata=key1:val1:key2:val2
-{"message":"Test", "metadata":{"metadata":{":authority":{"value":["localhost:5000"]}, "content-type":{"value":["application/grpc"]}, "key1":{"value":["val1"]}, "key2":{"value":["val2"]}, "user-agent":{"value":["grpc-go/1.80.0"]}}}}
+{"message":"Test", "metadata":{"metadata":{":authority":{"value":["localhost:5000"]}, "content-type":{"value":["application/grpc"]}, "key1":{"value":["val1"]}, "key2":{"value":["val2"]}, "user-agent":{"value":["grpc-go/1.81.0"]}}}}
 
 $ giro call rerost.giro.v1.TestService/EmptyCall {} --metadata=key1:val1:key2:val2
-{"status":"ok", "metadata":{"metadata":{":authority":{"value":["localhost:5000"]}, "content-type":{"value":["application/grpc"]}, "key1":{"value":["val1"]}, "key2":{"value":["val2"]}, "user-agent":{"value":["grpc-go/1.80.0"]}}}}
+{"status":"ok", "metadata":{"metadata":{":authority":{"value":["localhost:5000"]}, "content-type":{"value":["application/grpc"]}, "key1":{"value":["val1"]}, "key2":{"value":["val2"]}, "user-agent":{"value":["grpc-go/1.81.0"]}}}}
 
 $ giro empty_json rerost.giro.v1.EchoRequest
 {"message":""}


### PR DESCRIPTION
## Summary
- Supersedes #286 by including the v1.81.0 grpc upgrade together with the necessary e2e test fixture update
- Updates `e2etest/testdata/test.ct` user-agent expectation from `grpc-go/1.80.0` to `grpc-go/1.81.0` to match the new dependency version

## Why
PR #286 fails CI because the test fixture was last updated for grpc-go v1.80.0, but the PR now bumps to v1.81.0. The user-agent header emitted by the client embeds the grpc-go version, so the e2e snapshot diverges.

## Test plan
- [ ] CI `Test` job in the Go workflow passes (e2e tests verify the new user-agent string)
- [ ] All other checks (Go Build, lint, Check generate, Check GoReleaser, Check `make protoc`, Check Docker Build) remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)