### PR TITLE
Speed up lint CI job by using binary install mode

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -66,7 +66,6 @@ jobs:
         uses: golangci/golangci-lint-action@v9
         with:
           version: v2.12.2
-          install-mode: goinstall
   check-goreleaser:
     name: Check GoReleaser
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- lint job が他のジョブ(10〜40秒)に比べて1m26sかかっており、CI全体のボトルネックになっていた(参考: https://github.com/rerost/giro/actions/runs/28251888056)
- 原因は `.github/workflows/go.yml` の golangci-lint-action で `install-mode: goinstall` が指定されており、毎回ソースからビルドしていたため
- `install-mode` を指定しないことで action のデフォルト(`binary`)に切り替え、ビルド済みバイナリをダウンロードするようにした

Codex(gpt-5.5)によるレビュー済み: blocking な問題なし。当時 `goinstall` が追加されたのは古い golangci-lint バージョン時代の回避策と思われるが、現在は `go.mod` が `go 1.25.0`、golangci-lint は `v2.12.2` のフルバージョン指定で binary 取得に問題なし。

## Test plan
- [x] このPRのCIで lint job が短縮されることを確認(目標: ジョブ全体が1分以内)
- [x] lint job自体が問題なく成功することを確認